### PR TITLE
Simplify operational SRIOV model

### DIFF
--- a/nuage_neutronclient/net_topology.py
+++ b/nuage_neutronclient/net_topology.py
@@ -51,10 +51,10 @@ class SwitchportMappingCreate(extension.ClientExtensionCreate,
         parser.add_argument(
             '--host-id',
             help=_('Nova compute host id. hypervisor_hostname'))
-        #parser.add_argument(
-        #    '--pci-slot',
-        #    dest='pci_slot',
-        #    help=_('PCI id of the VF device.'))
+        parser.add_argument(
+            '--pci-slot',
+            dest='pci_slot',
+            help=_('Optional PCI id of a VF device on the given host'))
         parser.add_argument(
             '--physnet',
             dest='physnet',
@@ -64,7 +64,8 @@ class SwitchportMappingCreate(extension.ClientExtensionCreate,
 
     def args2body(self, args):
         body = {}
-        attributes = ['switch_id', 'switch_info', 'port_name', 'port_desc','host_id', 'physnet']
+        attributes = ['switch_id', 'switch_info', 'port_name', 'port_desc',
+                      'host_id', 'pci_slot', 'physnet']
         gw_mappingV20.update_dict(args, body, attributes)
 
         return {'switchport_mapping': body}
@@ -119,6 +120,9 @@ class SwitchportMappingUpdate(extension.ClientExtensionUpdate,
             '--host-id',
             help=_('Nova compute host id. hypervisor_hostname'))
         parser.add_argument(
+            '--pci-slot',
+            help=_('Optional PCI slot of a VF on the given host'))
+        parser.add_argument(
             '--physnet',
             dest='physnet',
             help=_('Physical network to which the NIC is connected.'))
@@ -126,7 +130,7 @@ class SwitchportMappingUpdate(extension.ClientExtensionUpdate,
     def args2body(self, args):
         body = {}
         attributes = ['switch_id', 'switch_info', 'port_name', 'port_desc',
-                      'host_id', 'physnet']
+                      'host_id', 'pci_slot', 'physnet']
         gw_mappingV20.update_dict(args, body, attributes)
 
         return {'switchport_mapping': body}

--- a/nuage_neutronclient/net_topology.py
+++ b/nuage_neutronclient/net_topology.py
@@ -40,24 +40,27 @@ class SwitchportMappingCreate(extension.ClientExtensionCreate,
             '--switch-info',
             dest='switch_info',
             help=_('Name of the switch device'))
-        parser.add_argument(
-            '--port-id',
-            dest='port_id',
-            help=_('Port mnemonic of phys port of the switch'))
+        #parser.add_argument(
+        #    '--port-id',
+        #    dest='port_id',
+        #    help=_('Port mnemonic of phys port of the switch'))
         parser.add_argument(
             '--host-id',
             help=_('Nova compute host id. hypervisor_hostname'))
+        #parser.add_argument(
+        #    '--pci-slot',
+        #    dest='pci_slot',
+        #    help=_('PCI id of the VF device.'))
         parser.add_argument(
-            '--pci-slot',
-            dest='pci_slot',
-            help=_('PCI id of the VF device.'))
+            '--phys-net',
+            dest='physnet',
+            help=_('Physical network to which the NIC is connected'))
 
         return parser
 
     def args2body(self, args):
         body = {}
-        attributes = ['switch_id', 'switch_info', 'port_id',
-                      'host_id', 'pci_slot']
+        attributes = ['switch_id', 'switch_info', 'host_id', 'physnet']
         gw_mappingV20.update_dict(args, body, attributes)
 
         return {'switchport_mapping': body}
@@ -67,7 +70,7 @@ class SwitchportMappingList(extension.ClientExtensionList, SwitchportMapping):
     """List switchport mappings."""
 
     shell_command = 'nuage-switchport-mapping-list'
-    list_columns = ['id', 'switch_id', 'port_id', 'host_id', 'pci_slot']
+    list_columns = ['id', 'switch_id', 'host_id', 'physnet']
     pagination_support = True
     sorting_support = True
 
@@ -100,22 +103,21 @@ class SwitchportMappingUpdate(extension.ClientExtensionUpdate,
             '--switch-info',
             dest='switch_info',
             help=_('Name of the gateway device'))
-        parser.add_argument(
-            '--port_id',
-            dest='port_id',
-            help=_('Port mnemoniq of phys port of gateway'))
+        #parser.add_argument(
+        #    '--port_id',
+        #    dest='port_id',
+        #    help=_('Port mnemoniq of phys port of gateway'))
         parser.add_argument(
             '--host-id',
             help=_('Nova compute host id. hypervisor_hostname'))
         parser.add_argument(
-            '--pci-slot',
-            dest='pci_slot',
-            help=_('PCI id of the device.'))
+            '--phys-net',
+            dest='physnet',
+            help=_('Physical network to which the NIC is connected.'))
 
     def args2body(self, args):
         body = {}
-        attributes = ['switch_id', 'switch_info', 'port_id',
-                      'host_id', 'pci_slot']
+        attributes = ['switch_id', 'switch_info', 'host_id', 'physnet']
         gw_mappingV20.update_dict(args, body, attributes)
 
         return {'switchport_mapping': body}

--- a/nuage_neutronclient/net_topology.py
+++ b/nuage_neutronclient/net_topology.py
@@ -56,7 +56,7 @@ class SwitchportMappingCreate(extension.ClientExtensionCreate,
         #    dest='pci_slot',
         #    help=_('PCI id of the VF device.'))
         parser.add_argument(
-            '--phys-net',
+            '--physnet',
             dest='physnet',
             help=_('Physical network to which the NIC is connected'))
 
@@ -119,7 +119,7 @@ class SwitchportMappingUpdate(extension.ClientExtensionUpdate,
             '--host-id',
             help=_('Nova compute host id. hypervisor_hostname'))
         parser.add_argument(
-            '--phys-net',
+            '--physnet',
             dest='physnet',
             help=_('Physical network to which the NIC is connected.'))
 

--- a/nuage_neutronclient/net_topology.py
+++ b/nuage_neutronclient/net_topology.py
@@ -40,10 +40,10 @@ class SwitchportMappingCreate(extension.ClientExtensionCreate,
             '--switch-info',
             dest='switch_info',
             help=_('Name of the switch device'))
-        #parser.add_argument(
-        #    '--port-id',
-        #    dest='port_id',
-        #    help=_('Port mnemonic of phys port of the switch'))
+        parser.add_argument(
+            '--port-name',
+            dest='port_name',
+            help=_('Physical port name of port on the switch'))
         parser.add_argument(
             '--host-id',
             help=_('Nova compute host id. hypervisor_hostname'))
@@ -60,7 +60,7 @@ class SwitchportMappingCreate(extension.ClientExtensionCreate,
 
     def args2body(self, args):
         body = {}
-        attributes = ['switch_id', 'switch_info', 'host_id', 'physnet']
+        attributes = ['switch_id', 'switch_info', 'port_name', 'host_id', 'physnet']
         gw_mappingV20.update_dict(args, body, attributes)
 
         return {'switchport_mapping': body}
@@ -70,7 +70,7 @@ class SwitchportMappingList(extension.ClientExtensionList, SwitchportMapping):
     """List switchport mappings."""
 
     shell_command = 'nuage-switchport-mapping-list'
-    list_columns = ['id', 'switch_id', 'host_id', 'physnet']
+    list_columns = ['id', 'switch_id', 'port_name', 'host_id', 'physnet']
     pagination_support = True
     sorting_support = True
 
@@ -103,10 +103,10 @@ class SwitchportMappingUpdate(extension.ClientExtensionUpdate,
             '--switch-info',
             dest='switch_info',
             help=_('Name of the gateway device'))
-        #parser.add_argument(
-        #    '--port_id',
-        #    dest='port_id',
-        #    help=_('Port mnemoniq of phys port of gateway'))
+        parser.add_argument(
+            '--port_name',
+            dest='port_name',
+            help=_('Physical port name of gateway port'))
         parser.add_argument(
             '--host-id',
             help=_('Nova compute host id. hypervisor_hostname'))
@@ -117,7 +117,7 @@ class SwitchportMappingUpdate(extension.ClientExtensionUpdate,
 
     def args2body(self, args):
         body = {}
-        attributes = ['switch_id', 'switch_info', 'host_id', 'physnet']
+        attributes = ['switch_id', 'switch_info', 'port_name', 'host_id', 'physnet']
         gw_mappingV20.update_dict(args, body, attributes)
 
         return {'switchport_mapping': body}

--- a/nuage_neutronclient/net_topology.py
+++ b/nuage_neutronclient/net_topology.py
@@ -45,6 +45,10 @@ class SwitchportMappingCreate(extension.ClientExtensionCreate,
             dest='port_name',
             help=_('Physical port name of port on the switch'))
         parser.add_argument(
+            '--port-desc',
+            dest='port_desc',
+            help=_('Port description to put in VSD'))
+        parser.add_argument(
             '--host-id',
             help=_('Nova compute host id. hypervisor_hostname'))
         #parser.add_argument(
@@ -60,7 +64,7 @@ class SwitchportMappingCreate(extension.ClientExtensionCreate,
 
     def args2body(self, args):
         body = {}
-        attributes = ['switch_id', 'switch_info', 'port_name', 'host_id', 'physnet']
+        attributes = ['switch_id', 'switch_info', 'port_name', 'port_desc','host_id', 'physnet']
         gw_mappingV20.update_dict(args, body, attributes)
 
         return {'switchport_mapping': body}
@@ -70,7 +74,7 @@ class SwitchportMappingList(extension.ClientExtensionList, SwitchportMapping):
     """List switchport mappings."""
 
     shell_command = 'nuage-switchport-mapping-list'
-    list_columns = ['id', 'switch_id', 'port_name', 'host_id', 'physnet']
+    list_columns = ['id', 'switch_id', 'port_uuid', 'host_id', 'physnet']
     pagination_support = True
     sorting_support = True
 
@@ -104,9 +108,13 @@ class SwitchportMappingUpdate(extension.ClientExtensionUpdate,
             dest='switch_info',
             help=_('Name of the gateway device'))
         parser.add_argument(
-            '--port_name',
+            '--port-name',
             dest='port_name',
             help=_('Physical port name of gateway port'))
+        parser.add_argument(
+            '--port-desc',
+            dest='port_desc',
+            help=_('Port description to put in VSD'))
         parser.add_argument(
             '--host-id',
             help=_('Nova compute host id. hypervisor_hostname'))
@@ -117,7 +125,8 @@ class SwitchportMappingUpdate(extension.ClientExtensionUpdate,
 
     def args2body(self, args):
         body = {}
-        attributes = ['switch_id', 'switch_info', 'port_name', 'host_id', 'physnet']
+        attributes = ['switch_id', 'switch_info', 'port_name', 'port_desc',
+                      'host_id', 'physnet']
         gw_mappingV20.update_dict(args, body, attributes)
 
         return {'switchport_mapping': body}

--- a/nuage_neutronclient/osc/v2/nuage_switchport_mapping.py
+++ b/nuage_neutronclient/osc/v2/nuage_switchport_mapping.py
@@ -31,7 +31,7 @@ RESOURCE_NAME_PLURAL = 'switchport_mappings'
 _attr_map = (('id', 'ID', column_util.LIST_BOTH),
              ('switch_id', 'Switch ID', column_util.LIST_BOTH),
              ('switch_info', 'Switch Info', column_util.LIST_BOTH),
-             # ('port_name', 'Port Name', column_util.LIST_BOTH),
+             ('port_name', 'Port Name', column_util.LIST_BOTH),
              ('host_id', 'Host ID', column_util.LIST_BOTH),
              ('physnet', 'Physical Network', column_util.LIST_BOTH),
              ('port_uuid', 'Port UUID', column_util.LIST_BOTH))

--- a/nuage_neutronclient/osc/v2/nuage_switchport_mapping.py
+++ b/nuage_neutronclient/osc/v2/nuage_switchport_mapping.py
@@ -31,9 +31,9 @@ RESOURCE_NAME_PLURAL = 'switchport_mappings'
 _attr_map = (('id', 'ID', column_util.LIST_BOTH),
              ('switch_id', 'Switch ID', column_util.LIST_BOTH),
              ('switch_info', 'Switch Info', column_util.LIST_BOTH),
-             ('port_id', 'Port ID', column_util.LIST_BOTH),
+             # ('port_id', 'Port ID', column_util.LIST_BOTH),
              ('host_id', 'Host ID', column_util.LIST_BOTH),
-             ('pci_slot', 'PCI slot', column_util.LIST_BOTH),
+             ('physnet', 'Physical Network', column_util.LIST_BOTH),
              ('port_uuid', 'Port UUID', column_util.LIST_BOTH))
 
 
@@ -48,27 +48,26 @@ def add_arguments_for_create_update(parser, is_create):
         dest='switch_info',
         help=_('Name of the switch device'),
         required=False)
-    parser.add_argument(
-        '--port-id',
-        dest='port_id',
-        help=_('Name of the port of the switch'),
-        required=is_create)
+    #parser.add_argument(
+    #    '--port-id',
+    #    dest='port_id',
+    #    help=_('Name of the port of the switch'),
+    #    required=is_create)
     parser.add_argument(
         '--host-id',
         help=_('Nova compute host id, hypervisor_hostname'),
         required=is_create)
     parser.add_argument(
-        '--pci-slot',
-        dest='pci_slot',
-        help=_('PCI id of the VF device.'),
+        '--phys-net',
+        dest='physnet',
+        help=_('Physical network for the given NIC.'),
         required=is_create)
 
 
 def get_body_update_create(parsed_args):
     body = {RESOURCE_NAME: {}}
     update_dict(parsed_args, body[RESOURCE_NAME],
-                ('switch_id', 'switch_info', 'port_id',
-                 'host_id', 'pci_slot'))
+                ('switch_id', 'switch_info', 'host_id', 'physnet'))
     return body
 
 

--- a/nuage_neutronclient/osc/v2/nuage_switchport_mapping.py
+++ b/nuage_neutronclient/osc/v2/nuage_switchport_mapping.py
@@ -30,7 +30,7 @@ RESOURCE_NAME_PLURAL = 'switchport_mappings'
 _attr_map = (('id', 'ID', column_util.LIST_BOTH),
              ('switch_id', 'Switch ID', column_util.LIST_BOTH),
              ('switch_info', 'Switch Info', column_util.LIST_BOTH),
-             ('port_name', 'Port Name', column_util.LIST_BOTH),
+             # ('port_name', 'Port Name', column_util.LIST_BOTH),
              ('host_id', 'Host ID[:PCI slot]', column_util.LIST_BOTH),
              ('physnet', 'Physical Network', column_util.LIST_BOTH),
              ('port_uuid', 'Port UUID', column_util.LIST_BOTH))

--- a/nuage_neutronclient/osc/v2/nuage_switchport_mapping.py
+++ b/nuage_neutronclient/osc/v2/nuage_switchport_mapping.py
@@ -65,7 +65,7 @@ def add_arguments_for_create_update(parser, is_create):
         help=_('Optional PCI slot of a VF on given host'),
         required=False)
     parser.add_argument(
-        '--phys-net',
+        '--physnet',
         dest='physnet',
         help=_('Physical network for the given NIC.'),
         required=is_create)

--- a/nuage_neutronclient/osc/v2/nuage_switchport_mapping.py
+++ b/nuage_neutronclient/osc/v2/nuage_switchport_mapping.py
@@ -31,7 +31,7 @@ RESOURCE_NAME_PLURAL = 'switchport_mappings'
 _attr_map = (('id', 'ID', column_util.LIST_BOTH),
              ('switch_id', 'Switch ID', column_util.LIST_BOTH),
              ('switch_info', 'Switch Info', column_util.LIST_BOTH),
-             ('port_name', 'Port Name', column_util.LIST_BOTH),
+             # ('port_name', 'Port Name', column_util.LIST_BOTH),
              ('host_id', 'Host ID', column_util.LIST_BOTH),
              ('physnet', 'Physical Network', column_util.LIST_BOTH),
              ('port_uuid', 'Port UUID', column_util.LIST_BOTH))
@@ -54,6 +54,11 @@ def add_arguments_for_create_update(parser, is_create):
         help=_('Physical port name of the switch port'),
         required=is_create)
     parser.add_argument(
+        '--port-desc',
+        dest='port_desc',
+        help=_('Port description to put in VSD'),
+        required=False)
+    parser.add_argument(
         '--host-id',
         help=_('Nova compute host id, hypervisor_hostname'),
         required=is_create)
@@ -67,7 +72,8 @@ def add_arguments_for_create_update(parser, is_create):
 def get_body_update_create(parsed_args):
     body = {RESOURCE_NAME: {}}
     update_dict(parsed_args, body[RESOURCE_NAME],
-                ('switch_id', 'switch_info', 'port_name', 'host_id', 'physnet'))
+                ('switch_id', 'switch_info', 'port_name', 'port_desc',
+                 'host_id', 'physnet'))
     return body
 
 

--- a/nuage_neutronclient/osc/v2/nuage_switchport_mapping.py
+++ b/nuage_neutronclient/osc/v2/nuage_switchport_mapping.py
@@ -27,15 +27,13 @@ LOG = logging.getLogger(__name__)
 RESOURCE_NAME = 'switchport_mapping'
 RESOURCE_NAME_PLURAL = 'switchport_mappings'
 
-
 _attr_map = (('id', 'ID', column_util.LIST_BOTH),
              ('switch_id', 'Switch ID', column_util.LIST_BOTH),
              ('switch_info', 'Switch Info', column_util.LIST_BOTH),
              ('port_name', 'Port Name', column_util.LIST_BOTH),
-             ('host_id', 'Host ID', column_util.LIST_BOTH),
+             ('host_id', 'Host ID[:PCI slot]', column_util.LIST_BOTH),
              ('physnet', 'Physical Network', column_util.LIST_BOTH),
              ('port_uuid', 'Port UUID', column_util.LIST_BOTH))
-
 
 def add_arguments_for_create_update(parser, is_create):
     parser.add_argument(
@@ -63,6 +61,10 @@ def add_arguments_for_create_update(parser, is_create):
         help=_('Nova compute host id, hypervisor_hostname'),
         required=is_create)
     parser.add_argument(
+        '--pci-slot',
+        help=_('Optional PCI slot of a VF on given host'),
+        required=False)
+    parser.add_argument(
         '--phys-net',
         dest='physnet',
         help=_('Physical network for the given NIC.'),
@@ -73,7 +75,7 @@ def get_body_update_create(parsed_args):
     body = {RESOURCE_NAME: {}}
     update_dict(parsed_args, body[RESOURCE_NAME],
                 ('switch_id', 'switch_info', 'port_name', 'port_desc',
-                 'host_id', 'physnet'))
+                 'host_id', 'pci_slot', 'physnet'))
     return body
 
 

--- a/nuage_neutronclient/osc/v2/nuage_switchport_mapping.py
+++ b/nuage_neutronclient/osc/v2/nuage_switchport_mapping.py
@@ -31,8 +31,8 @@ _attr_map = (('id', 'ID', column_util.LIST_BOTH),
              ('switch_id', 'Switch ID', column_util.LIST_BOTH),
              ('switch_info', 'Switch Info', column_util.LIST_BOTH),
              # ('port_name', 'Port Name', column_util.LIST_BOTH),
-             ('host_id', 'Host ID[:PCI slot]', column_util.LIST_BOTH),
              ('physnet', 'Physical Network', column_util.LIST_BOTH),
+             ('host_id', 'Host ID[:PCI slot]', column_util.LIST_BOTH),
              ('port_uuid', 'Port UUID', column_util.LIST_BOTH))
 
 def add_arguments_for_create_update(parser, is_create):

--- a/nuage_neutronclient/osc/v2/nuage_switchport_mapping.py
+++ b/nuage_neutronclient/osc/v2/nuage_switchport_mapping.py
@@ -31,7 +31,7 @@ RESOURCE_NAME_PLURAL = 'switchport_mappings'
 _attr_map = (('id', 'ID', column_util.LIST_BOTH),
              ('switch_id', 'Switch ID', column_util.LIST_BOTH),
              ('switch_info', 'Switch Info', column_util.LIST_BOTH),
-             # ('port_id', 'Port ID', column_util.LIST_BOTH),
+             ('port_name', 'Port Name', column_util.LIST_BOTH),
              ('host_id', 'Host ID', column_util.LIST_BOTH),
              ('physnet', 'Physical Network', column_util.LIST_BOTH),
              ('port_uuid', 'Port UUID', column_util.LIST_BOTH))
@@ -48,11 +48,11 @@ def add_arguments_for_create_update(parser, is_create):
         dest='switch_info',
         help=_('Name of the switch device'),
         required=False)
-    #parser.add_argument(
-    #    '--port-id',
-    #    dest='port_id',
-    #    help=_('Name of the port of the switch'),
-    #    required=is_create)
+    parser.add_argument(
+        '--port-name',
+        dest='port_name',
+        help=_('Physical port name of the switch port'),
+        required=is_create)
     parser.add_argument(
         '--host-id',
         help=_('Nova compute host id, hypervisor_hostname'),
@@ -67,7 +67,7 @@ def add_arguments_for_create_update(parser, is_create):
 def get_body_update_create(parsed_args):
     body = {RESOURCE_NAME: {}}
     update_dict(parsed_args, body[RESOURCE_NAME],
-                ('switch_id', 'switch_info', 'host_id', 'physnet'))
+                ('switch_id', 'switch_info', 'port_name', 'host_id', 'physnet'))
     return body
 
 


### PR DESCRIPTION
This patch modifies the switchport mapping concept by making the PCI slot optional. 
For deployments where physnets map to unique NICs on each host (i.e. {physnet,host} uniquely determines a mapping to a specific switch port ) we can simplify the process by wild-carding the PCI slot. This avoids having to discover which VFs use which PCI IDs on each compute - greatly reducing both the time and complexity of making this mapping